### PR TITLE
feat: Support CodeBlock's `lang` property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3587,7 +3587,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3608,12 +3609,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3628,17 +3631,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3755,7 +3761,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3767,6 +3774,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3781,6 +3789,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3788,12 +3797,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3812,6 +3823,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3892,7 +3904,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3904,6 +3917,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3989,7 +4003,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4025,6 +4040,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4044,6 +4060,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4087,12 +4104,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/parse.js
+++ b/src/parse.js
@@ -143,7 +143,8 @@ class Converter {
       return [];
     }
     const range = this.locationToRange(loc);
-    return [{ type: "CodeBlock", value: raw, loc, range, raw }];
+    const attributes = typeof elem.getAttributes === "function" ? elem.getAttributes() : {};
+    return [{ type: "CodeBlock", lang: attributes.language, value: raw, loc, range, raw }];
   }
 
   convertList(elem, { min, max }) {

--- a/test/__snapshots__/snapshots.test.js.snap
+++ b/test/__snapshots__/snapshots.test.js.snap
@@ -5105,6 +5105,7 @@ first level",
       "type": "Paragraph",
     },
     Object {
+      "lang": "ruby",
       "loc": Object {
         "end": Object {
           "column": 16,
@@ -5132,6 +5133,7 @@ doc = Asciidoctor.load '*This* is http://asciidoc.org[AsciiDoc]!', header_footer
 puts doc.convert",
     },
     Object {
+      "lang": "html",
       "loc": Object {
         "end": Object {
           "column": 7,
@@ -9328,6 +9330,7 @@ Object {
         Object {
           "children": Array [
             Object {
+              "lang": "ruby",
               "loc": Object {
                 "end": Object {
                   "column": 34,

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -225,6 +225,7 @@ puts 'Hello, world!'
   expect(node.children[0]).toEqual(
     oc({
       type: "CodeBlock",
+      lang: "ruby",
       value: "puts 'Hello, world!'"
     })
   );


### PR DESCRIPTION
Add `lang` property to `CodeBlock` node.

Markdown

	```js
	code
	```

Markdown AST

```json
{
  "type": "Document",
  "children": [
    {
      "type": "CodeBlock",
      "lang": "js",
      "value": "code",
      "loc": {
        "start": {
          "line": 1,
          "column": 0
        },
        "end": {
          "line": 3,
          "column": 3
        }
      },
      "range": [
        0,
        14
      ],
      "raw": "```js\ncode\n```"
    }
  ],
  "loc": {
    "start": {
      "line": 1,
      "column": 0
    },
    "end": {
      "line": 3,
      "column": 3
    }
  },
  "range": [
    0,
    14
  ],
  "raw": "```js\ncode\n```"
}
```

Asciidctor:

```asciidoc
[source,ruby]
----
puts 'Hello, world!'
----
```

Asciidctor AST:

```json
{
  "type": "Document",
  "children": [
    {
      "type": "CodeBlock",
      "lang": "ruby",
      "value": "puts 'Hello, world!'",
      "loc": {
        "start": {
          "line": 3,
          "column": 0
        },
        "end": {
          "line": 3,
          "column": 20
        }
      },
      "range": [
        19,
        39
      ],
      "raw": "puts 'Hello, world!'"
    }
  ],
  "loc": {
    "start": {
      "line": 3,
      "column": 0
    },
    "end": {
      "line": 3,
      "column": 20
    }
  },
  "range": [
    19,
    39
  ],
  "raw": "[source,ruby]\n----\nputs 'Hello, world!'\n----"
}
```