### PR TITLE
fix: correct parse CodeBlock that includes // comment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3587,7 +3587,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3608,12 +3609,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3628,17 +3631,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3755,7 +3761,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3767,6 +3774,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3781,6 +3789,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3788,12 +3797,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3812,6 +3823,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3892,7 +3904,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3904,6 +3917,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3989,7 +4003,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4025,6 +4040,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4044,6 +4060,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4087,12 +4104,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/parse.js
+++ b/src/parse.js
@@ -143,7 +143,8 @@ class Converter {
       return [];
     }
     const range = this.locationToRange(loc);
-    return [{ type: "CodeBlock", value: raw, loc, range, raw }];
+    const attributes = typeof elem.getAttributes === "function" ? elem.getAttributes() : {};
+    return [{ type: "CodeBlock", lang: attributes.language, value: raw, loc, range, raw }];
   }
 
   convertList(elem, { min, max }) {

--- a/test/__snapshots__/snapshots.test.js.snap
+++ b/test/__snapshots__/snapshots.test.js.snap
@@ -116,12 +116,12 @@ Object {
               "line": 2,
             },
             "start": Object {
-              "column": -1,
+              "column": 0,
               "line": 1,
             },
           },
           "range": Array [
-            -1,
+            0,
             87,
           ],
           "raw": "The Article Title",
@@ -136,12 +136,12 @@ Object {
           "line": 2,
         },
         "start": Object {
-          "column": -1,
+          "column": 0,
           "line": 1,
         },
       },
       "range": Array [
-        -1,
+        0,
         87,
       ],
       "raw": "The Article Title",
@@ -1968,12 +1968,12 @@ of AsciiDoc labeled lists.",
       "line": 124,
     },
     "start": Object {
-      "column": -1,
+      "column": 0,
       "line": 1,
     },
   },
   "range": Array [
-    -1,
+    0,
     3373,
   ],
   "raw": "// NOTE: This is the article example from the AsciiDoc Python project
@@ -2103,6 +2103,99 @@ A glossary term::
 
 A second glossary term::
   The corresponding (indented) definition.",
+  "type": "Document",
+}
+`;
+
+exports[`Snapshot testing Test Snapshot:code comment.adoc 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "loc": Object {
+            "end": Object {
+              "column": 41,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            0,
+            41,
+          ],
+          "raw": "This is CodeBlock that includes comments.",
+          "type": "Str",
+          "value": "This is CodeBlock that includes comments.",
+        },
+      ],
+      "loc": Object {
+        "end": Object {
+          "column": 41,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        41,
+      ],
+      "raw": "This is CodeBlock that includes comments.",
+      "type": "Paragraph",
+    },
+    Object {
+      "lang": "javascript",
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        68,
+        100,
+      ],
+      "raw": "// comment
+var a = 1;
+// comment",
+      "type": "CodeBlock",
+      "value": "// comment
+var a = 1;
+// comment",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 10,
+      "line": 7,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    100,
+  ],
+  "raw": "This is CodeBlock that includes comments.
+
+[source,javascript]
+----
+// comment
+var a = 1;
+// comment
+----",
   "type": "Document",
 }
 `;

--- a/test/__snapshots__/snapshots.test.js.snap
+++ b/test/__snapshots__/snapshots.test.js.snap
@@ -5105,6 +5105,7 @@ first level",
       "type": "Paragraph",
     },
     Object {
+      "lang": "ruby",
       "loc": Object {
         "end": Object {
           "column": 16,
@@ -5132,6 +5133,7 @@ doc = Asciidoctor.load '*This* is http://asciidoc.org[AsciiDoc]!', header_footer
 puts doc.convert",
     },
     Object {
+      "lang": "html",
       "loc": Object {
         "end": Object {
           "column": 7,
@@ -9328,6 +9330,7 @@ Object {
         Object {
           "children": Array [
             Object {
+              "lang": "ruby",
               "loc": Object {
                 "end": Object {
                   "column": 34,

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -231,6 +231,25 @@ puts 'Hello, world!'
   );
 });
 
+test("code includes comment", () => {
+  const node = parse(`\
+[source,js]
+----
+// comment
+var foo = 1;
+----
+`);
+  testAST(node);
+  expect(node.children[0]).toEqual(
+      oc({
+        type: "CodeBlock",
+        lang: "js",
+        value: `// comment
+var foo = 1;`
+      })
+  );
+});
+
 test("headings", () => {
   const node = parse(`\
 = Title

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -225,6 +225,7 @@ puts 'Hello, world!'
   expect(node.children[0]).toEqual(
     oc({
       type: "CodeBlock",
+      lang: "ruby",
       value: "puts 'Hello, world!'"
     })
   );

--- a/test/snapshot_fixtures/code-comment.adoc
+++ b/test/snapshot_fixtures/code-comment.adoc
@@ -1,0 +1,8 @@
+This is CodeBlock that includes comments.
+
+[source,javascript]
+----
+// comment
+var a = 1;
+// comment
+----


### PR DESCRIPTION
It is depended on #4 
Should merge #4 at first.

Previously, CodeBlock that includes `//` is skipped.
In this PR, fix the CodeBlock includes `//` as value.