### PR TITLE
Add file extension '.asciidoc'

### DIFF
--- a/src/AsciidoctorProcessor.js
+++ b/src/AsciidoctorProcessor.js
@@ -9,7 +9,7 @@ export class AsciidoctorProcessor {
   }
 
   static availableExtensions() {
-    return [".adoc", ".asciidoctor", ".asc"];
+    return [".adoc", ".asciidoc", ".asc", ".asciidoctor"];
   }
 
   processor(ext) {


### PR DESCRIPTION
README.mdには`.asciidoc`が対応拡張子として記載がありますが、実際には検出されていなかったので追加しました。一応`.asciidoctor`は残してあります。

よろしくお願いいたします。